### PR TITLE
feat: add support for tinfoil

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -48,6 +48,29 @@
         "node": ">=20.0.0"
       }
     },
+    "../tinfoil-node": {
+      "name": "tinfoil",
+      "version": "0.6.1",
+      "license": "AGPL-3.0-or-later",
+      "dependencies": {
+        "@ai-sdk/openai-compatible": "^1.0.10",
+        "ai": "^5.0.19",
+        "dotenv": "^17.2.1",
+        "openai": "^5.13.1",
+        "ts-node": "^10.9.2",
+        "undici": "^7.14.0"
+      },
+      "devDependencies": {
+        "@types/jest": "^29.5.12",
+        "@types/node": "^24.3.0",
+        "@typescript-eslint/eslint-plugin": "^8.40.0",
+        "@typescript-eslint/parser": "^8.40.0",
+        "eslint": "^8.57.0",
+        "jest": "^29.7.0",
+        "ts-jest": "^29.4.1",
+        "typescript": "^5.9.2"
+      }
+    },
     "node_modules/@alcalzone/ansi-tokenize": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/@alcalzone/ansi-tokenize/-/ansi-tokenize-0.1.3.tgz",
@@ -4440,9 +4463,9 @@
       }
     },
     "node_modules/dotenv": {
-      "version": "17.1.0",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.1.0.tgz",
-      "integrity": "sha512-tG9VUTJTuju6GcXgbdsOuRhupE8cb4mRgY5JLRCh4MtGoVo3/gfGUtOMwmProM6d0ba2mCFvv+WrpYJV6qgJXQ==",
+      "version": "17.2.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.1.tgz",
+      "integrity": "sha512-kQhDYKZecqnM0fCnzI5eIv5L4cAe/iRI+HqMbO/hbRdTAeXDG+M9FjipUxNfbARuEg4iHIbhnhs78BCHNbSxEQ==",
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"
@@ -10333,6 +10356,10 @@
       "integrity": "sha512-PKvy1rVF1RibfF3JlXBSP0Jrcw2uq3yXdgcEXtKTYn3QJ/cBRBHDnrJ5jHky+MENZ6DIPwNUGWpkVx+7joCpNA==",
       "license": "MIT"
     },
+    "node_modules/tinfoil": {
+      "resolved": "../tinfoil-node",
+      "link": true
+    },
     "node_modules/tinybench": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
@@ -10751,9 +10778,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.10.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.10.0.tgz",
-      "integrity": "sha512-u5otvFBOBZvmdjWLVW+5DAc9Nkq8f24g0O9oY7qw2JVIF1VocIFoyz9JFkuVOS2j41AufeO0xnlweJ2RLT8nGw==",
+      "version": "7.14.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.14.0.tgz",
+      "integrity": "sha512-Vqs8HTzjpQXZeXdpsfChQTlafcMQaaIwnGwLam1wudSSjlJeQ3bw1j+TLPePgrCnCpUXx7Ba5Pdpf5OBih62NQ==",
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"
@@ -11935,6 +11962,7 @@
         "simple-git": "^3.28.0",
         "strip-ansi": "^7.1.0",
         "tiktoken": "^1.0.21",
+        "tinfoil": "0.6.1",
         "undici": "^7.10.0",
         "ws": "^8.18.0"
       },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -49,6 +49,7 @@
     "simple-git": "^3.28.0",
     "strip-ansi": "^7.1.0",
     "tiktoken": "^1.0.21",
+    "tinfoil": "0.6.1",
     "undici": "^7.10.0",
     "ws": "^8.18.0"
   },


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Adds first-class Tinfoil support by replacing the OpenAI client with TinfoilAI in the content generator. Chat completions, streaming, and tool calls now work with Tinfoil using the same config (apiKey/baseURL).

- **New Features**
  - Swap OpenAI SDK for TinfoilAI in openaiContentGenerator.
  - Update types for messages, chunks, and tools; safely handle tool_call.function.
  - Keep existing config flow (apiKey, baseURL, timeouts).

- **Dependencies**
  - Add tinfoil 0.6.1 to core; lockfile links to ../tinfoil-node.
  - Bump dotenv to 17.2.1 and undici to 7.14.0.

<!-- End of auto-generated description by cubic. -->

